### PR TITLE
URL scalar type

### DIFF
--- a/server/graphql/scalars/index.js
+++ b/server/graphql/scalars/index.js
@@ -1,0 +1,5 @@
+import URL from './url';
+
+export default {
+  URL,
+}

--- a/server/graphql/scalars/url.js
+++ b/server/graphql/scalars/url.js
@@ -1,4 +1,4 @@
-import { GraphQLScalarType } from 'grapql';
+import { GraphQLScalarType } from 'graphql';
 import { Kind } from 'graphql/language';
 
 const URLRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/;

--- a/server/graphql/scalars/url.js
+++ b/server/graphql/scalars/url.js
@@ -1,0 +1,19 @@
+import { GraphQLScalarType } from 'grapql';
+import { Kind } from 'graphql/language';
+
+const URLRegex = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[\-;:&=\+\$,\w]+@)?[A-Za-z0-9\.\-]+|(?:www\.|[\-;:&=\+\$,\w]+@)[A-Za-z0-9\.\-]+)((?:\/[\+~%\/\.\w\-_]*)?\??(?:[\-\+=&;%@\.\w_]*)#?(?:[\.\!\/\\\w]*))?)/;
+
+const URLValidation = (value) => URLRegex.test(value) ? value : null;
+
+export default new GraphQLScalarType({
+  name: 'URL',
+  description: 'URL link data type',
+  parseValue: URLValidation,
+  serialize: URLValidation,
+  parseLiteral: ({kind, value}) => {
+    if(kind == Kind.STRING){
+      return URLValidation(value);
+    }
+    return null;
+  }
+});


### PR DESCRIPTION
close #12 

### What's new?
**URL** new type for graphql schema. 
This indicates that input field with URL type only accepts valid URL address. On the other hand, if query returns field with that type it must be URL address.